### PR TITLE
Fix crash caused by long headings.

### DIFF
--- a/lib/cli/output.js
+++ b/lib/cli/output.js
@@ -14,7 +14,7 @@ const COLOR_STYLES = {
   bad:         (t) => chalk.red(t),
 
   heading:     (t) => {
-    const padding = 78 - 8 - chalk.stripColor(t).length;
+    const padding = Math.max(0, 78 - 8 - chalk.stripColor(t).length);
     return `====[ ${t} ` + ']' + '='.repeat(padding);
   },
 


### PR DESCRIPTION
Chaplain does not crash when heading text is longer than 70 characters.
